### PR TITLE
adding playwright traces

### DIFF
--- a/js-playwright/playwright.config.js
+++ b/js-playwright/playwright.config.js
@@ -29,7 +29,7 @@ module.exports = defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
this PR adds playwright traces based on: retain-on-failure

'retain-on-failure' - Record a trace for each test, but remove it from successful test runs.

https://playwright.dev/docs/trace-viewer#tracing-on-ci