### PR TITLE
Fix npm registry configuration for private JFrog packages

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -56,7 +56,8 @@ jobs:
           fi
       - name: Configure .npmrc
         run: |
-          echo "${{ secrets.EVINCED_NPM_TOKEN }}" > ~/.npmrc
+          echo "@evinced:registry=https://evinced.jfrog.io/artifactory/api/npm/restricted-npm/" > ~/.npmrc
+          echo "//evinced.jfrog.io/artifactory/api/npm/restricted-npm/:_authToken=${JFROG_AUTH_TOKEN}" >>  ~/.npmrc
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -56,8 +56,8 @@ jobs:
           fi
       - name: Configure .npmrc
         run: |
-          echo "@evinced:registry=https://evinced.jfrog.io/artifactory/api/npm/restricted-npm/" > ~/.npmrc
-          echo "//evinced.jfrog.io/artifactory/api/npm/restricted-npm/:_authToken=${JFROG_AUTH_TOKEN}" >>  ~/.npmrc
+          npm config set registry https://evinced.jfrog.io/artifactory/api/npm/restricted-npm/
+          npm config set //evinced.jfrog.io/artifactory/api/npm/restricted-npm/:_authToken ${{ secrets.EVINCED_NPM_TOKEN }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem
GitHub Actions checks were failing because npm was attempting to fetch private packages from the public npmjs registry instead of our protected JFrog Artifactory registry.

## Solution
Updated the workflow to use `npm config set` commands to properly configure the npm registry and authentication before package installation.

## Changes
- Modified `.github/workflows/github-actions.yml` to set registry URL to JFrog Artifactory
- Added authentication token configuration for the private registry
- Ensures package resolution uses the correct protected registry
