### PR TITLE
repro for 2028

### DIFF
--- a/unit-tester/react/package.json
+++ b/unit-tester/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@evinced/unit-tester": "^2.31.0",
+    "@evinced/unit-tester": "^2.29.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/unit-tester/react/src/setupTests.js
+++ b/unit-tester/react/src/setupTests.js
@@ -10,7 +10,8 @@ import { configure } from "@evinced/unit-tester";
 
 configure({
   serviceAccountId: process.env.EVINCED_SERVICE_ID,
-  serviceAccountSecret: process.env.EVINCED_API_KEY,
+  // serviceAccountSecret: process.env.EVINCED_API_KEY,
+  offlineToken: process.env.EVINCED_WEB_OFFLINE_TOKEN
 });
 
 // configure({


### PR DESCRIPTION
steps to repro:

go to the unit-tester/react test files and run: npm test -- --watchAll=false --runInBand 2>&1 | grep -E "PASS|FAIL|MaxListeners|Warning"

The warning occurs because of how Jest runs tests combined with how the unit-tester SDK handles offline token authentication.                                             
                     
The mechanics:
                                                              
setupTests.js runs once per test file in the Jest process.  With --runInBand, all 28 test files share a single Node.js  process, so configure() gets called 28 times in the same process.                                                  

Each configure() call with an offline token causes the SDK to register a new message event listener on an internal EventEmitter — but it never removes the previous one. Node.js's default limit is 10 listeners per EventEmitter. On the 11th test file, Node detects 11 listeners on the same EventEmitter and emits the warning.

Why only with offline token:                                
   
With online credentials (serviceAccountId + serviceAccountSecret), authentication is handled differently — the SDK likely makes an HTTP call to validate once and caches the result, so repeated configure() calls don't stack up listeners. With an offline token, the SDK sets up a local token validation listener each time instead.

Why it doesn't appear without --runInBand:                  
   
Jest's default parallel mode spawns multiple worker processes. With 28 files across e.g. 4 workers, each worker only handles ~7 files — never reaching the limit of 10.     
                                                            
The fix on the SDK side would be to call emitter.removeAllListeners() or reuse the existing listener before adding a new one in configure().              