### PR TITLE
Fix claude-code-action invocation in web-a11y-autofix

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           mode: agent
           direct_prompt: ${{ steps.load_prompt.outputs.content }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AI_GITHUB }}
           github_token: ${{ secrets.DEMO_FE_PAT }}
           claude_env: |
             REPORT_PATH: ${{ github.workspace }}/_autofix_input/${{ steps.cfg.outputs.report_basename }}

--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -21,6 +21,7 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  id-token: write
 
 jobs:
   autofix:
@@ -97,37 +98,38 @@ jobs:
           git config user.email "a11y-autofix@evinced.com"
           git config user.name  "Evinced A11y Autofix"
 
-      - name: Write runtime .mcp.json
-        env:
-          EVINCED_API_KEY: ${{ secrets.EVINCED_API_KEY }}
+      - name: Load agent prompt
+        id: load_prompt
         run: |
-          cat > .mcp.json <<JSON
           {
-            "mcpServers": {
-              "evinced": {
-                "command": "npx",
-                "args": ["-y", "@evinced/web-mcp"],
-                "env": { "EVINCED_API_KEY": "${EVINCED_API_KEY}" }
-              }
-            }
-          }
-          JSON
+            echo 'content<<PROMPT_EOF'
+            cat prompts/a11y-autofix.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
 
-      # NOTE: anthropics/claude-code-action@beta input names below (`prompt_file`, `mcp_config`)
-      # may differ from the current action API. If this step fails with "unexpected input", check
-      # https://github.com/anthropics/claude-code-action and swap to the documented input names.
       - name: Run Claude agent
         uses: anthropics/claude-code-action@beta
-        env:
-          REPORT_PATH: ${{ github.workspace }}/_autofix_input/${{ steps.cfg.outputs.report_basename }}
-          TARGET_REPO_PATH: ${{ github.workspace }}/_autofix_target
-          CONFIG_PATH: ${{ github.workspace }}/a11y-autofix.config.json
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          GH_TOKEN: ${{ secrets.DEMO_FE_PAT }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          prompt_file: prompts/a11y-autofix.md
-          mcp_config: .mcp.json
+          mode: agent
+          direct_prompt: ${{ steps.load_prompt.outputs.content }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.DEMO_FE_PAT }}
+          claude_env: |
+            REPORT_PATH: ${{ github.workspace }}/_autofix_input/${{ steps.cfg.outputs.report_basename }}
+            TARGET_REPO_PATH: ${{ github.workspace }}/_autofix_target
+            CONFIG_PATH: ${{ github.workspace }}/a11y-autofix.config.json
+            DRY_RUN: ${{ inputs.dry_run || 'false' }}
+            GH_TOKEN: ${{ secrets.DEMO_FE_PAT }}
+          mcp_config: |
+            {
+              "mcpServers": {
+                "evinced": {
+                  "command": "npx",
+                  "args": ["-y", "@evinced/web-mcp"],
+                  "env": { "EVINCED_API_KEY": "${{ secrets.EVINCED_API_KEY }}" }
+                }
+              }
+            }
 
       - name: Notify Slack
         if: always()


### PR DESCRIPTION
## Summary

The first dispatch of the new `web-a11y-autofix.yml` workflow (after PR #250 merged) surfaced three issues with how it invokes `anthropics/claude-code-action@beta`. This PR addresses all three.

### Fixes
1. **`prompt_file` is not a valid input.** Replace with `direct_prompt` populated from `prompts/a11y-autofix.md` via a new "Load agent prompt" step that writes the file contents into `$GITHUB_OUTPUT` using a HEREDOC.
2. **OIDC token probe fails without `id-token: write`.** Add the permission to the workflow's `permissions:` block. The action probes OIDC even when `anthropic_api_key` is set.
3. **`anthropic_api_key` / `github_token` must be `with:` inputs, not env vars.** Moved into the action's `with:` block. Runtime paths (`REPORT_PATH`, etc.) now flow to Claude's subprocess via the action's `claude_env` input, and `mcp_config` is inlined (dropping the now-redundant "Write runtime .mcp.json" step).

## Test plan
- [ ] Dispatch `web-a11y-autofix.yml` manually on `main` with `dry_run=true`; verify the agent step starts cleanly (no input warnings, no OIDC failure).
- [ ] Live dispatch with `dry_run=false`; verify one PR per Evinced finding appears in `EvincedShane/demo-fe`.