### PR TITLE
Use ANTHROPIC_API_KEY for claude-code-action auth

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           mode: agent
           direct_prompt: ${{ steps.load_prompt.outputs.content }}
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_AI_GITHUB }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.DEMO_FE_PAT }}
           claude_env: |
             REPORT_PATH: ${{ github.workspace }}/_autofix_input/${{ steps.cfg.outputs.report_basename }}


### PR DESCRIPTION
## Summary

The previous PR (#251) tried `claude_code_oauth_token: ${{ secrets.ANTHROPIC_AI_GITHUB }}`, but the action still failed auth — that org secret isn't the OAuth-token format the action expects. Swap to the standard `anthropic_api_key` input sourced from a new repo secret `ANTHROPIC_API_KEY` (`sk-ant-...` API key).

One-line change in `.github/workflows/web-a11y-autofix.yml`.

## Test plan
- [ ] Dispatch `web-a11y-autofix.yml` on `main` with `dry_run=true` after this merges; verify the agent step authenticates and starts running.