### PR TITLE
Grant agent Bash + Evinced MCP tools so it can actually open PRs

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -114,6 +114,7 @@ jobs:
           direct_prompt: ${{ steps.load_prompt.outputs.content }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.DEMO_FE_PAT }}
+          allowed_tools: "Bash,Edit,MultiEdit,Glob,Grep,LS,Read,Write,mcp__evinced__evinced_get_webpage_issue_details,mcp__evinced__evinced_analyze_webpage,mcp__evinced__evinced_import_report"
           claude_env: |
             REPORT_PATH: ${{ github.workspace }}/_autofix_input/${{ steps.cfg.outputs.report_basename }}
             TARGET_REPO_PATH: ${{ github.workspace }}/_autofix_target


### PR DESCRIPTION
## Summary

The first successful smoke-run (workflow_dispatch dry_run=true on commit `757c5f3`) finished green but produced zero output PRs. The log revealed why:

```
ALLOWED_TOOLS: Edit,MultiEdit,Glob,Grep,LS,Read,Write
DISALLOWED_TOOLS: WebSearch,WebFetch
```

`claude-code-action@beta`'s default allowlist is read-only. The agent had no access to `Bash`, so it couldn't run `gh pr create`, `git`, `node` (for our helpers), or any side-effect tool. It saw the 3 issues in `evMcpDemo.json`, attempted to satisfy the prompt by writing a Node.js script that *would* perform the work, and stopped there.

This PR adds an explicit `allowed_tools` input listing the tools the prompt actually needs:

- `Bash` — `gh`, `git`, `node` invocations
- `Edit,MultiEdit,Glob,Grep,LS,Read,Write` — match the action's previous defaults
- `mcp__evinced__evinced_get_webpage_issue_details`, `mcp__evinced__evinced_analyze_webpage`, `mcp__evinced__evinced_import_report` — the Evinced MCP tools registered via `mcp_config`

## Test plan
- [ ] After merge, dispatch `web-a11y-autofix.yml` on `main` with `dry_run=true`. Verify the agent's log shows `[DRY-RUN]` prefixes on every `gh pr create` / `git push` invocation, indicating it tried the real flow and was correctly gated by the dry-run prompt logic.
- [ ] Then dispatch with `dry_run=false`. Verify one PR per issue appears in `EvincedShane/demo-fe`.