### PR TITLE
Rewrite a11y agent prompt: imperative + MCP-centric

### DIFF
--- a/prompts/a11y-autofix.md
+++ b/prompts/a11y-autofix.md
@@ -1,68 +1,169 @@
-# A11y Auto-Fix Agent Prompt
+# A11y Auto-Fix — Execute Now
 
-You are running inside GitHub Actions, invoked by `web-a11y-autofix.yml` in `support-golden-examples`. Your job is to translate Evinced accessibility findings into pull requests against a Next.js front-end repository.
+You are an agent running INSIDE a GitHub Actions step. You are NOT writing code that someone else will run later. Every numbered step below requires you to invoke a tool RIGHT NOW. Read a step, do it, move to the next step. Do not summarize. Do not plan. Do not describe what you would do. Do it.
 
-## Environment
+## Hard rules (violating any of these = run FAILED)
 
-- `$REPORT_PATH` — absolute path to a JSON file containing an array of Evinced issues. Use the `loadIssues` helper (`web/playwright/js/scripts/a11y-autofix-helpers/loadIssues.mjs`) to read and validate it.
-- `$TARGET_REPO_PATH` — absolute path to a fresh clone of `EvincedShane/demo-fe`, checked out at the configured base branch.
-- `$CONFIG_PATH` — absolute path to `a11y-autofix.config.json`.
-- `$DRY_RUN` — `"true"` or `"false"`. When `"true"`, do NOT run `gh pr create`, `git push`, or `gh pr comment`; log the would-be invocation instead. Branch creation in the local clone is still allowed.
-- The Evinced MCP is registered as `evinced` and provides `evinced_get_webpage_issue_details` for fetching expanded issue context by signature.
-- `gh` CLI is authenticated against the target repo via `DEMO_FE_PAT`.
+- Do NOT create any `.mjs`, `.js`, `.ts`, `.sh`, `.py` file at the repo root or in any directory under this repo. The only files you may create are: (a) markdown files under `$TARGET_REPO_PATH/a11y-findings/` and (b) edits via the `Edit` tool to existing `.tsx`/`.jsx` files under `$TARGET_REPO_PATH`.
+- Do NOT invoke `node` on any script you wrote. The only `node` invocations allowed are calling the pre-existing helpers under `web/playwright/js/scripts/a11y-autofix-helpers/`.
+- Do NOT write a "main loop" or "agent" — YOU are the loop, executing one tool call at a time.
+- If you reach the end of this prompt without making MCP tool calls AND running `gh pr create` (or its `[DRY-RUN]` equivalent), you have FAILED.
 
-## Procedure
+## Environment (already set, just reference)
 
-Read `$CONFIG_PATH`. For each issue in `$REPORT_PATH`, do the following IN ORDER. Stop after `maxIssuesPerRun` issues.
+- `$REPORT_PATH` — Evinced issues JSON file
+- `$TARGET_REPO_PATH` — fresh clone of the FE repo
+- `$CONFIG_PATH` — `a11y-autofix.config.json`
+- `$DRY_RUN` — `"true"` skips network mutations (git push, gh pr create, gh pr comment); branch creation and tracking-file writes still happen locally
 
-### 1. Resolve source
+## Step 1 — Read config
 
-Use the `resolveRoute` helper to map `issue.url` → a path inside `$TARGET_REPO_PATH` under `target.routeRoot`. If `resolveRoute` returns `null`, tag the issue `route-unresolved` and skip to step 3 with `patch="(none)"`.
+Use the `Read` tool on `$CONFIG_PATH`. Remember these keys: `target.owner`, `target.repo`, `target.baseBranch`, `target.baseUrl`, `target.routeRoot`, `prBranchPrefix`, `trackingFileDir`, `maxIssuesPerRun`.
 
-If the resolved `page.tsx` imports components from `src/components/**` or similar, read those imports and find the JSX subtree that owns `issue.selector`. Stop at the first file you would actually edit.
+## Step 2 — Load issues via the Evinced MCP
 
-### 2. Propose patch
+Call `mcp__evinced__evinced_import_report` with `file=$REPORT_PATH` and `model=claude-opus-4-7`. The tool returns the report's issue list (or a `reportId` you can follow up with).
 
-Make the minimal JSX edit that resolves the issue (e.g., add `alt=""`, fix `aria-label`, correct landmark nesting). Do NOT touch unrelated lines. If you are not confident the edit is correct, set `patch="(none)"` and tag `manual-review`.
+If `evinced_import_report` returns an error OR the issue list is empty BUT the file is non-empty, fall back: use `Read` on `$REPORT_PATH`, parse as JSON, find the array — it may be the top-level value, or nested under a key like `issues`, `data.issues`, or per-page `pages[*].issues`. Flatten to a single array. Each item must have some stable identifier; use whichever field looks like a signature/id/hash, and refer to its value as `<signature>` for the rest of this run.
 
-### 3. Write tracking entry
+Log the issue count. If zero, write a summary saying "no issues, nothing to do" and STOP (run is successful).
 
-Write `${trackingFileDir}/<signature>.md` (overwrite if it exists). Contents:
+## Step 3 — Process each issue
 
-- Issue title, severity, WCAG ref (if present in issue data)
-- URL, selector, link to screenshot (if present)
-- Resolved source file
-- Proposed patch as a fenced diff, or `manual review needed`
-- Final line: `Verification: human must confirm fix matches intent.`
+Cap the loop at `maxIssuesPerRun` (default 20). For each issue in order, run Steps 3.a through 3.f. Do NOT skip steps. Do NOT batch.
 
-### 4. Open or update PR
+### 3.a — Get rich details via the MCP
 
-Use the `signatureToBranch` helper for the branch name (`prBranchPrefix` + slugified signature).
+Call `mcp__evinced__evinced_get_webpage_issue_details` with `issueSignature=<signature>` and `model=claude-opus-4-7`. Capture: rule title, severity, WCAG ref, DOM snippet, selector, screenshot URL/id, bounding box, AND the remediation instructions field. Evinced's remediation text is your PRIMARY guide for the patch. The summary JSON is just a table of contents.
 
-Pre-check existing state via `gh pr list --repo $TARGET --state all --search "in:title <signature>"`:
+If the MCP call fails for one issue, log `outcome=api-error` for that signature and continue to the next issue.
 
-- Open PR with same signature → check out the branch, replay the edits, `git push --force-with-lease`. If `--force-with-lease` is rejected, tag `branch-conflict`, post a comment on the PR explaining (do NOT retry with `--force`), and continue to the next issue.
-- Closed/merged PR with same signature → tag `skipped-closed-pr`, do nothing.
-- No matching PR → create branch from base, write changes, `git push`, `gh pr create` with title `[a11y] <issue title>`, labels `a11y,automated`, body that links the tracking file and includes the diff summary.
+### 3.b — Pre-check for an existing PR
 
-When all issues are processed, post a single summary comment on each PR touched this run.
+Run via `Bash`:
 
-## Hard rules
+```
+gh pr list \
+  --repo <target.owner>/<target.repo> \
+  --state all \
+  --search "in:title <signature>" \
+  --json number,state,headRefName
+```
 
-- Never push to `main` of the target repo.
-- Never delete branches you did not create.
-- Never edit files outside the resolved component file and the `trackingFileDir`.
-- Stop processing after `maxIssuesPerRun` issues even if more remain.
-- When `$DRY_RUN` is `"true"`, prefix every log line about a network mutation with `[DRY-RUN]` and skip the actual command.
+- If a result has `state=MERGED` or `state=CLOSED`: log `outcome=skipped-closed-pr` and SKIP to the next issue.
+- If a result has `state=OPEN`: note the `headRefName` for Step 3.e; this issue will refresh that branch.
+- If no results: this issue gets a new branch.
 
-## Output
+### 3.c — Resolve the source file
 
-Emit a final JSON object on stdout in this shape (one entry per processed issue):
+Strip `<target.baseUrl>` from the issue's URL. Walk `$TARGET_REPO_PATH/<target.routeRoot>/` for the matching Next.js App Router `page.tsx`, handling:
+
+- literal directory segments (preferred match)
+- route groups `(group)` (consume zero URL segments)
+- dynamic `[id]` (consume one URL segment)
+
+Use `LS`, `Glob`, and `Read` tools — NOT a script. If no `page.tsx` matches the URL path, log `outcome=route-unresolved` and proceed to Step 3.d to write a tracking record (skip the JSX edit; the PR is still useful as a tracking artifact).
+
+If `page.tsx` imports other components, follow imports via `Read` + `Grep` to find the JSX element that owns the issue's selector. Stop at the first file you would actually edit.
+
+### 3.d — Apply the JSX edit
+
+Use the `Edit` tool (NOT `Bash` + `sed`) to apply the minimal change that implements Evinced's remediation instructions verbatim. For example, if the remediation says "Add `aria-label='Submit'`", literally add `aria-label="Submit"` to that JSX element. Do NOT touch unrelated lines.
+
+If you are not confident the edit matches Evinced's intent, skip the JSX edit and tag this issue `manual-review`.
+
+### 3.e — Write the tracking file
+
+Use the `Write` tool to create `$TARGET_REPO_PATH/<trackingFileDir>/<signature>.md`. Content:
+
+```
+# <issue rule title>
+
+- Signature: <signature>
+- Severity: <severity>
+- WCAG: <wcag-ref>
+- URL: <issue.url>
+- Selector: <issue.selector>
+- Screenshot: <url or id>
+- Source file: <resolved path or "route-unresolved">
+
+## Evinced remediation guidance
+
+<verbatim from MCP>
+
+## Applied patch
+
+\`\`\`diff
+<the diff you applied, or "manual review needed">
+\`\`\`
+
+Verification: human must confirm fix matches intent.
+```
+
+### 3.f — Branch, commit, and PR
+
+Slugify the signature into a branch name. Run:
+
+```
+node -e "import('./web/playwright/js/scripts/a11y-autofix-helpers/signatureToBranch.mjs').then(({signatureToBranch}) => console.log(signatureToBranch('<signature>', '<prBranchPrefix>')))"
+```
+
+via `Bash` to get the branch name. Then:
+
+```
+cd $TARGET_REPO_PATH
+git checkout -b <branch>   # OR `git checkout <branch>` if 3.b found an existing open PR's branch
+git add -A
+git commit -m "[a11y] <rule title>"
+```
+
+If `$DRY_RUN=true`:
+- Log `[DRY-RUN] would push and open PR for <signature>`.
+- Log `outcome=pr-opened` (or `pr-updated`) for this signature with `prUrl=null`.
+- Move to the next issue.
+
+If `$DRY_RUN=false`:
+- For a NEW branch:
+  ```
+  git push --set-upstream origin <branch>
+  gh pr create \
+    --repo <target.owner>/<target.repo> \
+    --base <target.baseBranch> \
+    --head <branch> \
+    --title "[a11y] <rule title>" \
+    --body "$(cat <trackingFileDir>/<signature>.md)" \
+    --label a11y --label automated
+  ```
+  Capture the returned PR URL. Log `outcome=pr-opened`.
+- For an EXISTING branch:
+  ```
+  git push --force-with-lease
+  ```
+  If accepted: `gh pr comment <pr-number> --body "Refreshed by run ${GITHUB_RUN_ID}"`. Log `outcome=pr-updated`.
+  If rejected: do NOT use `--force`. Run `gh pr comment <pr-number> --body "Branch was edited externally; autofix skipping refresh."` Log `outcome=branch-conflict`.
+
+## Step 4 — Emit run summary
+
+After all issues are processed, print to stdout (no shell needed — just include it in your final response):
 
 ```json
 {
   "runSummary": [
-    { "signature": "<sig>", "outcome": "pr-opened|pr-updated|manual-review|route-unresolved|branch-conflict|skipped-closed-pr|api-error", "prUrl": "<url|null>" }
+    {"signature": "...", "outcome": "pr-opened|pr-updated|manual-review|route-unresolved|branch-conflict|skipped-closed-pr|api-error", "prUrl": "..."}
   ]
 }
 ```
+
+## Success criteria
+
+This run is SUCCESSFUL only if:
+
+1. You called `mcp__evinced__evinced_get_webpage_issue_details` at least once per non-skipped issue.
+2. You ran `gh pr create` (or its `[DRY-RUN]` log equivalent) for each issue that was not `route-unresolved` or `skipped-closed-pr`.
+3. The total count of PRs opened or updated (in real or dry-run mode) equals the total issues processed minus `route-unresolved` minus `skipped-closed-pr` minus `api-error`.
+
+If the run summary shows fewer PRs than expected, the run has FAILED.
+
+## Reminder
+
+DO NOT write a script that does this. DO NOT plan. DO THE WORK NOW, one tool call at a time, starting with Step 1.


### PR DESCRIPTION
## Why

After PR #253 landed (allowed_tools fix), the agent ran successfully but **didn't open any PRs**. The log showed it had built its own `a11y-autofix-agent.mjs` orchestration script, run it locally, and self-reported success — exactly the failure mode the previous prompt couldn't prevent.

Two root causes:

1. **Declarative prompt → blueprint behavior.** Phrases like "For each issue, do X" read as a spec the LLM should implement, not a procedure to execute.
2. **MCP was optional.** The prompt mentioned the Evinced MCP as something the agent "may call." It almost never did.

## What changes

Rewritten `prompts/a11y-autofix.md` (140+/-39 lines):

- **Imperative form.** Every step starts with "NOW call X" or "NOW run Y". A "Hard rules" block at the top forbids creating any new helper scripts and declares "if you reach the end without making MCP tool calls and running gh pr create, you have FAILED."
- **MCP load-bearing.** Step 2 mandates `mcp__evinced__evinced_import_report`. Step 3.a mandates `mcp__evinced__evinced_get_webpage_issue_details` per issue, treating its remediation guidance as the primary source of truth for the patch. The summary JSON is now a fallback only.
- **Explicit success criteria.** Step 4 defines the run as successful only if the count of `gh pr create` (or `[DRY-RUN]` log equivalent) invocations equals issues minus skipped/unresolved.
- **Edit-not-sed.** JSX changes must go through the `Edit` tool, not `Bash + sed`, so they appear cleanly in the agent's tool trace.

## Test plan

- [ ] Dispatch `web-a11y-autofix.yml` on `main` with `dry_run=true`. Verify the agent's tool trace shows: 1× `Read $CONFIG_PATH`, 1× `evinced_import_report`, N× `evinced_get_webpage_issue_details` (one per issue), and N× `[DRY-RUN]` log lines for the would-be `gh pr create`.
- [ ] Dispatch with `dry_run=false`. Verify one PR per issue appears in `EvincedShane/demo-fe`, each with a tracking file under `a11y-findings/<signature>.md` containing Evinced's remediation guidance.