### PR TITLE
Fix Evinced MCP server: real package name + private-registry auth

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -140,6 +140,9 @@ jobs:
           git config user.email "a11y-autofix@evinced.com"
           git config user.name  "Evinced A11y Autofix"
 
+      - name: Configure .npmrc for Evinced private registry
+        run: echo "${{ secrets.EVINCED_NPM_TOKEN }}" > ~/.npmrc
+
       - name: Load agent prompt for this signature
         id: load_prompt
         env:
@@ -173,8 +176,12 @@ jobs:
               "mcpServers": {
                 "evinced": {
                   "command": "npx",
-                  "args": ["-y", "@evinced/web-mcp"],
-                  "env": { "EVINCED_API_KEY": "${{ secrets.EVINCED_API_KEY }}" }
+                  "args": ["-y", "@evinced/mcp-server-web"],
+                  "type": "stdio",
+                  "env": {
+                    "EVINCED_SERVICE_ID": "${{ secrets.EVINCED_SERVICE_ID }}",
+                    "EVINCED_API_KEY": "${{ secrets.EVINCED_API_KEY }}"
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Why

Per developer.evinced.com/MCP-Servers/web-mcp-server, the published package is `@evinced/mcp-server-web` (not `@evinced/web-mcp`) and lives on the Evinced JFrog private registry — so `npx -y` needs `.npmrc` configured before it can resolve the package. Authentication also requires BOTH `EVINCED_SERVICE_ID` and `EVINCED_API_KEY` for the token-auth flow.

This explains why every matrix job in the previous live run logged `"The MCP call failed, so I'll fall back to reading the report directly"` — the MCP server never installed.

## Three changes to `.github/workflows/web-a11y-autofix.yml`

1. **New step `Configure .npmrc for Evinced private registry`** in the `fix` matrix job, right before the agent step. Same one-liner pattern `web-js.yml` already uses (`echo "$EVINCED_NPM_TOKEN" > ~/.npmrc`).
2. **`mcp_config` package name** changed from `@evinced/web-mcp` to `@evinced/mcp-server-web`; added `"type": "stdio"` per the docs.
3. **MCP env block** now includes both `EVINCED_SERVICE_ID` and `EVINCED_API_KEY`.

Server key (`evinced`) is unchanged, so the `allowed_tools` list (`mcp__evinced__evinced_*`) keeps working without modification.

## Test plan

- [ ] Dispatch with `dry_run=true` after merge. Verify ≥1 matrix job's log shows the agent actually calling `mcp__evinced__evinced_get_webpage_issue_details` and getting a real response (no "MCP call failed" fallback line).
- [ ] Dispatch with `dry_run=false`. Verify PRs land in `EvincedShane/demo-fe`, and that each tracking file's "Evinced remediation guidance" section quotes the MCP server's response rather than just the summary JSON's `ruleId`.