### PR TITLE
Run Evinced MCP server in --headless mode

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -176,7 +176,7 @@ jobs:
               "mcpServers": {
                 "evinced": {
                   "command": "npx",
-                  "args": ["-y", "@evinced/mcp-server-web"],
+                  "args": ["-y", "@evinced/mcp-server-web", "--headless"],
                   "type": "stdio",
                   "env": {
                     "EVINCED_SERVICE_ID": "${{ secrets.EVINCED_SERVICE_ID }}",


### PR DESCRIPTION
Previous live run on main showed `mcp_servers[0].status=failed` for the Evinced server, meaning the action registered it but the server's startup failed. Per developer.evinced.com docs, the default Chromium mode launches a browser at startup; the docs also offer a separate `--headless` flag for automated CI workflows. Try that — single-arg diff, no other changes.

If this fixes it: matrix jobs will start showing real `mcp__evinced__evinced_get_webpage_issue_details` tool-use entries in logs instead of the "MCP call failed, fall back to JSON" line.

If this doesn't fix it: next step is pre-installing Playwright Chromium and/or adding a diagnostic step that runs `npm view @evinced/mcp-server-web` to confirm `.npmrc` auth resolves the package.