### PR TITLE
Install + --login Evinced MCP server before agent step

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -143,6 +143,19 @@ jobs:
       - name: Configure .npmrc for Evinced private registry
         run: echo "${{ secrets.EVINCED_NPM_TOKEN }}" > ~/.npmrc
 
+      - name: Install Evinced MCP server (pre-fetch + cache)
+        run: |
+          npm install -g @evinced/mcp-server-web
+          which evinced-mcp-server-web || true
+          npx @evinced/mcp-server-web --version || true
+
+      - name: Authenticate Evinced MCP server
+        env:
+          EVINCED_SERVICE_ID: ${{ secrets.EVINCED_SERVICE_ID }}
+          EVINCED_API_KEY: ${{ secrets.EVINCED_API_KEY }}
+        run: |
+          npx @evinced/mcp-server-web --login
+
       - name: Load agent prompt for this signature
         id: load_prompt
         env:


### PR DESCRIPTION
Per the Evinced docs, the setup order should be:

1. `.npmrc` with the JFrog registry mapping (already done)
2. Install `@evinced/mcp-server-web` from that registry
3. `npx @evinced/mcp-server-web --login` with `EVINCED_SERVICE_ID` + `EVINCED_API_KEY` env vars set
4. Then the runtime `mcp_config` block is consumed by claude-code-action

This PR adds steps 2 and 3 between the existing `.npmrc` step and the agent step in the fix matrix job:

```yaml
- name: Install Evinced MCP server (pre-fetch + cache)
  run: |
    npm install -g @evinced/mcp-server-web
    which evinced-mcp-server-web || true
    npx @evinced/mcp-server-web --version || true

- name: Authenticate Evinced MCP server
  env:
    EVINCED_SERVICE_ID: ${{ secrets.EVINCED_SERVICE_ID }}
    EVINCED_API_KEY: ${{ secrets.EVINCED_API_KEY }}
  run: |
    npx @evinced/mcp-server-web --login
```

The runtime `mcp_config` block is unchanged (still `--headless`, still passes the same env vars). When claude-code-action spawns the server, it should now pick up both the installed binary and the cached login state.

## Test plan
- [ ] Dispatch with `dry_run=true`. Check any matrix job log:
  - `mcp_servers[0].status` should be `connected` (not `failed`)
  - Agent tool trace should include `tool_name: mcp__evinced__evinced_get_webpage_issue_details`
  - No more "The MCP call failed, so I'll fall back" lines
- [ ] If install or login step itself fails, the log will show the exact error (404 for package, 401/403 for auth, etc.) — we then know what to fix.