### PR TITLE
Skip broken @evinced/mcp-server-web install scripts

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -143,18 +143,29 @@ jobs:
       - name: Configure .npmrc for Evinced private registry
         run: echo "${{ secrets.EVINCED_NPM_TOKEN }}" > ~/.npmrc
 
-      - name: Install Evinced MCP server (pre-fetch + cache)
+      - name: Install Evinced MCP server (skip broken postinstall scripts)
         run: |
-          npm install -g @evinced/mcp-server-web
-          which evinced-mcp-server-web || true
-          npx @evinced/mcp-server-web --version || true
+          # @evinced/mcp-server-web@1.0.28's postinstall tries to run
+          # `vite build` (devDep, not present after `npm install`) and pulls
+          # `keytar` which fails to prebuild on a fresh runner. We use token
+          # auth (env vars), not the OS-keychain login flow, so keytar isn't
+          # needed at runtime. Skip both with --ignore-scripts and
+          # --omit=optional.
+          npm install -g @evinced/mcp-server-web --ignore-scripts --omit=optional
 
-      - name: Authenticate Evinced MCP server
-        env:
-          EVINCED_SERVICE_ID: ${{ secrets.EVINCED_SERVICE_ID }}
-          EVINCED_API_KEY: ${{ secrets.EVINCED_API_KEY }}
-        run: |
-          npx @evinced/mcp-server-web --login
+          echo "--- discovering binary name ---"
+          NODE_BIN_DIR="$(dirname $(which node))"
+          ls -la "$NODE_BIN_DIR" | grep -i evinced || echo "no evinced binary on PATH"
+          ls -la "$NODE_BIN_DIR" | grep -i mcp || echo "no mcp binary on PATH"
+
+          echo "--- package directory ---"
+          PKG_DIR="$NODE_BIN_DIR/../lib/node_modules/@evinced/mcp-server-web"
+          if [ -d "$PKG_DIR" ]; then
+            echo "package installed at $PKG_DIR"
+            cat "$PKG_DIR/package.json" | jq '.bin, .main' || true
+          else
+            echo "::error::package not found at $PKG_DIR"
+          fi
 
       - name: Load agent prompt for this signature
         id: load_prompt


### PR DESCRIPTION
Previous run revealed why the MCP server has been failing to start: `@evinced/mcp-server-web@1.0.28` has two install-time scripts that crash on a fresh Ubuntu runner:

1. **keytar's postinstall** tries `prebuild-install` (not on PATH), falls back to `npm run build` (also not on PATH). keytar is a transitive dep for OS-keychain access.
2. **`@evinced/mcp-server-web`'s own install script** runs `vite build` — vite is a devDep that doesn't get installed by `npm install`. Likely a packaging bug worth filing upstream.

Both fail with exit 127, breaking the entire install. This is why `npx -y @evinced/mcp-server-web` in the action's `mcp_config` was silently failing too — same error, just swallowed.

## Fix

- Install with `--ignore-scripts --omit=optional` to skip the broken scripts. Token auth via env vars doesn't need keytar at runtime.
- Drop the `--login` step entirely (it requires keytar).
- Add a discovery step that prints the resulting binary location + `bin`/`main` from `package.json`. The next run's log will show us the binary name — we'll then update `mcp_config` to invoke the binary directly instead of going through `npx -y` (which would re-trigger the install failure).

## Test plan
- [ ] Dispatch with `dry_run=true` after merge. Look in any matrix-job log for the `--- discovering binary name ---` block. Capture the binary name. Then a follow-up PR will change `mcp_config` to use that binary directly.

If even the `--ignore-scripts` install fails: we'll see the error in plain text, and the next move is likely to file the packaging issue with Evinced and find another path (HTTP MCP endpoint, different package version, etc.).