### PR TITLE
mcp_config: use installed evinced-mcp-server binary directly

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -199,8 +199,8 @@ jobs:
             {
               "mcpServers": {
                 "evinced": {
-                  "command": "npx",
-                  "args": ["-y", "@evinced/mcp-server-web", "--headless"],
+                  "command": "evinced-mcp-server",
+                  "args": ["--headless"],
                   "type": "stdio",
                   "env": {
                     "EVINCED_SERVICE_ID": "${{ secrets.EVINCED_SERVICE_ID }}",


### PR DESCRIPTION
Confirmed in PR #260's run: install succeeded with `--ignore-scripts --omit=optional`, and the binary is on PATH as `evinced-mcp-server` (a symlink to `dist/cli.js`). But the runtime `mcp_config` still used `npx -y @evinced/mcp-server-web --headless`, which re-ran the broken postinstall when claude-code-action spawned the server, so `mcp_servers[0].status` stayed at `failed`.

One-character fix: point `mcp_config.command` at the installed binary directly:

```yaml
"command": "evinced-mcp-server",
"args": ["--headless"],
```

The previous `Install Evinced MCP server` step does the actual install, so by the time the agent step runs, the binary is on PATH and the action can spawn it without npm involvement.

## Test plan
- [ ] Dispatch with `dry_run=true` after merge. In any matrix-job log, look for `mcp_servers[0].status` — should be `connected` (or similar) instead of `failed`. The agent's tool trace should include `tool_name: mcp__evinced__evinced_get_webpage_issue_details` rather than the "MCP call failed" fallback line.
- [ ] Spot-check one tracking file's "Evinced remediation guidance" section — it should now quote Evinced's MCP-returned remediation text rather than agent-derived guidance from the rule ID.
- [ ] If still failing: the binary itself crashes at startup. Then we need actual stderr from the server process; will add a fresh diagnostic step in the next PR.