### PR TITLE
Don't skip optional deps when installing Evinced MCP server

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -152,7 +152,13 @@ jobs:
         # --omit=optional. The published tarball already ships
         # dist/cli.js, so the binary works without running build scripts.
         run: |
-          npm install -g @evinced/mcp-server-web --ignore-scripts --omit=optional
+          # IMPORTANT: do not pass --omit=optional. @evinced/auth's
+          # device-flow.js statically imports `open`, which is an optional
+          # dep — skipping optionals causes ERR_MODULE_NOT_FOUND at server
+          # startup even when using token auth. --ignore-scripts alone is
+          # enough to bypass keytar's prebuild-install and the package's
+          # own vite-build postinstall.
+          npm install -g @evinced/mcp-server-web --ignore-scripts
           which evinced-mcp-server
 
       - name: Install Chromium for MCP server (docs Troubleshooting)


### PR DESCRIPTION
PR #263's smoke test paid off. Real stderr from `evinced-mcp-server --headless` running standalone:

```
Error: Cannot find package 'open/index.js' imported from .../@evinced/auth/dist/auth0/device-flow.js
ERR_MODULE_NOT_FOUND
```

`@evinced/auth/dist/auth0/device-flow.js` statically imports `open` (npm package for opening URLs in the default browser, used by the device-flow auth path). `open` is declared as an optional dep, so `--omit=optional` skipped it. The import runs at module load, so the server crashes before our token-auth credentials ever get checked.

## One-line fix

Drop `--omit=optional`. Keep `--ignore-scripts` — that's still needed to bypass keytar's broken prebuild-install and the package's own vite-build postinstall.

## Test plan

- [ ] Merge + dispatch `dry_run=true`. The `Verify MCP server starts standalone` step should now hang (waiting for stdio MCP handshake) or print valid MCP JSON-RPC frames within the 30s window, instead of crashing on ERR_MODULE_NOT_FOUND. Then in the agent step, `mcp_servers[0].status` should flip from `failed` to `connected`.