### PR TITLE
Embed PAT in cloned remote URL so git push authenticates

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -137,6 +137,11 @@ jobs:
           gh repo clone "${{ needs.extract.outputs.target_owner }}/${{ needs.extract.outputs.target_repo }}" ./_autofix_target -- \
             --branch "${{ needs.extract.outputs.target_branch }}" --depth 50
           cd ./_autofix_target
+          # Embed the PAT in the remote URL so `git push` from the agent's
+          # Bash subshell authenticates non-interactively. `gh repo clone`
+          # leaves the remote as plain https://github.com/... which fails
+          # with "could not read Username" when git tries to push.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ needs.extract.outputs.target_owner }}/${{ needs.extract.outputs.target_repo }}.git"
           git config user.email "a11y-autofix@evinced.com"
           git config user.name  "Evinced A11y Autofix"
 


### PR DESCRIPTION
Yesterday's live run (`dry_run=false`) hit a clean auth failure at the agent's git push step:

```
git push --set-upstream origin a11y/fix-005f251d
→ fatal: could not read Username for 'https://github.com': No such device or address
```

3 of 30 matrix jobs completed (importing the report, fetching MCP details, writing tracking files, committing locally) — then `git push` aborted because:

- `gh repo clone` leaves the remote URL as plain `https://github.com/...` (no embedded credentials).
- Our env block exports `GH_TOKEN`, which lets `gh` CLI commands work — but `git push` doesn't read `GH_TOKEN` and there's no credential helper configured.
- With no TTY, git's interactive username prompt errors out.

## Fix

One line added to the Clone step, right after `gh repo clone`:

```bash
git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/<owner>/<repo>.git"
```

After this, every subsequent `git push` from the agent's bash uses the embedded token automatically. `gh pr create` / `gh pr comment` keep working via the existing GH_TOKEN env var.

## Test plan

- [ ] Merge + dispatch `dry_run=true`. Confirm no regression — should still produce `pr-opened-dry-run` outcomes.
- [ ] Dispatch `dry_run=false`. Watch for real PRs in `EvincedShane/demo-fe` (one per signature, ~30 total).