### PR TITLE
extract: drop non-string signatures from matrix

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -97,7 +97,12 @@ jobs:
             exit 1
           fi
           # Recursive scan for `signature` fields anywhere in the JSON structure.
-          SIGNATURES=$(jq -c '[.. | objects | select(has("signature")) | .signature] | unique' "$FILE")
+          # `select(type == "string")` filters out non-string signature values
+          # (the Evinced report has at least one nested object whose own
+          # `signature` field is itself an object — picking it would inject
+          # a phantom matrix entry whose `${{ matrix.signature }}` interpolates
+          # as `[object Object]` and breaks the prompt-substitution step).
+          SIGNATURES=$(jq -c '[.. | objects | select(has("signature")) | .signature | select(type == "string")] | unique' "$FILE")
           COUNT=$(echo "$SIGNATURES" | jq 'length')
           if [ "$COUNT" = "0" ]; then
             echo "::warning::No issue signatures found in $FILE"


### PR DESCRIPTION
Most recent run (`25882498375`) was marked failed even though all 30 `fix (<sig>)` matrix jobs succeeded. A 31st phantom `fix` job (no signature in the name) failed at the `Load agent prompt for this signature` step, with the downstream agent step's name showing `— Object`.

Root cause: the `extract` job's jq pulled a `signature` field whose value was an object rather than a hex string from somewhere in the report's JSON tree. That object interpolated as `[object Object]` in the matrix and broke the prompt-substitution sed.

## One-line fix

```diff
- SIGNATURES=$(jq -c '[.. | objects | select(has("signature")) | .signature] | unique' "$FILE")
+ SIGNATURES=$(jq -c '[.. | objects | select(has("signature")) | .signature | select(type == "string")] | unique' "$FILE")
```

Filters out anything that isn't a string before the result hits the matrix. The 30 real issue signatures all match; the phantom object entry is dropped.

## Test plan

- [ ] Dispatch `dry_run=true`. Confirm 30 `fix (<sig>)` jobs and no bare `fix` job in the run.
- [ ] Run conclusion should be `success` overall.