### PR TITLE
Re-dispatch workflow_run via workflow_dispatch so claude-code-action accepts it

### DIFF
--- a/.github/workflows/web-a11y-autofix.yml
+++ b/.github/workflows/web-a11y-autofix.yml
@@ -20,14 +20,40 @@ concurrency:
 
 permissions:
   contents: read
-  actions: read
+  actions: write       # `write` so the re-dispatch job can call createWorkflowDispatch
   id-token: write
 
 jobs:
+  # claude-code-action@beta rejects `workflow_run` as an event type
+  # ("Unsupported event type: workflow_run"). When this workflow is
+  # triggered by web-js.yml completing, we self-dispatch via the API so
+  # the real work runs in a workflow_dispatch context, which the action
+  # does support.
+  re-dispatch:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Re-dispatch this workflow as workflow_dispatch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'web-a11y-autofix.yml',
+              ref: 'main',
+              inputs: { dry_run: 'false' }
+            });
+            core.info('Dispatched web-a11y-autofix.yml as workflow_dispatch on main (dry_run=false).');
+
   extract:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Skip when triggered by workflow_run — the re-dispatch job above will
+    # fire a fresh workflow_dispatch invocation that runs this job in a
+    # supported event context.
+    if: github.event_name != 'workflow_run'
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
       issue_count: ${{ steps.list.outputs.count }}
@@ -114,7 +140,7 @@ jobs:
 
   fix:
     needs: extract
-    if: needs.extract.outputs.issue_count != '0'
+    if: github.event_name != 'workflow_run' && needs.extract.outputs.issue_count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -244,7 +270,7 @@ jobs:
 
   summary:
     needs: [extract, fix]
-    if: always()
+    if: always() && github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack


### PR DESCRIPTION
## Why

`anthropics/claude-code-action@beta` errors with "Unsupported event type: workflow_run" in its prepare step. Our auto-cascade trigger from `web-js.yml` → `web-a11y-autofix.yml` was always going to fail at the agent step. Manual `workflow_dispatch` runs worked because the action supports that event type.

## Fix

Two parts in `web-a11y-autofix.yml`:

1. **New `re-dispatch` job** runs only when triggered by `workflow_run`. Uses `actions/github-script@v7` to call `createWorkflowDispatch` on this same workflow with `dry_run=false`. The dispatched invocation runs in a supported event context.
2. **Gate `extract`/`fix`/`summary` jobs** with `github.event_name != 'workflow_run'` so they only run in the dispatched invocation, not the original `workflow_run` invocation.

Permission bump: `actions: read` → `actions: write` so `createWorkflowDispatch` can be called by the workflow's `GITHUB_TOKEN`.

## End-to-end after this lands

```
web-js.yml succeeds
   → workflow_run event fires
      → web-a11y-autofix.yml runs ONLY its re-dispatch job
         → calls createWorkflowDispatch
            → web-a11y-autofix.yml fires AGAIN as workflow_dispatch
               → extract + fix matrix + summary run normally
                  → PRs land in demo-fe
```

## Test plan

- [ ] After merge: `gh workflow run web-js.yml -R GetEvinced/sdk-examples-pub --ref main`. Watch for two consecutive autofix runs in the Actions UI:
  1. The first (triggered by workflow_run) runs only `re-dispatch`, then exits.
  2. The second (triggered by workflow_dispatch from the API call) runs `extract` → `fix` matrix → `summary`, opening PRs in `demo-fe`.
- [ ] Manual dispatch (`gh workflow run web-a11y-autofix.yml ... -f dry_run=true`) still works unchanged.